### PR TITLE
IllegalDefense Mode added to lib

### DIFF
--- a/rcsc/game_mode.h
+++ b/rcsc/game_mode.h
@@ -94,7 +94,10 @@ public:
 
         GoalieCatch_, // Left | Right
         ExtendHalf,
-        MODE_MAX
+        MODE_MAX,
+
+        IllegalDefense_, // Left | Right
+
     };
 
 
@@ -173,6 +176,8 @@ public:
 
     "yellow_card_SIDE_UNUM"
     "red_card_SIDE_UNUM"
+
+    "illegal_defense_{l|r}"
     */
 
     typedef std::pair< Type, rcsc::SideID > Pair; //!< alias of the pair of playmode type and side type

--- a/rcsc/rcg/types.h
+++ b/rcsc/rcg/types.h
@@ -110,6 +110,7 @@ enum PlayerStatus {
     FOUL_CHARGED     = 0x00020000, // player is frozen by intentional tackle foul
     YELLOW_CARD     = 0x00040000,
     RED_CARD        = 0x00080000,
+    ILLEGAL_DEFENSE = 0x00100000,
 };
 
 

--- a/rcsc/types.h
+++ b/rcsc/types.h
@@ -157,7 +157,9 @@ enum PlayMode {
     PM_PenaltyMiss_Right,
     PM_PenaltyScore_Left,
     PM_PenaltyScore_Right,
-    PM_MAX
+    PM_MAX,
+    PM_IllegalDefense_Left,
+    PM_IllegalDefense_Right,
 };
 
 //! playmode string table defined in rcssserver.
@@ -211,8 +213,8 @@ enum PlayMode {
       "penalty_miss_r", \
       "penalty_score_l", \
       "penalty_score_r", \
-      "", \
-      "", \
+      "illegal_defense_r", \
+      "illegal_defense_l", \
       "", \
       "", \
       "" \

--- a/rcsc/util/game_mode.cpp
+++ b/rcsc/util/game_mode.cpp
@@ -161,6 +161,9 @@ MapHolder::MapHolder()
     M_playmode_map["penalty_winner_l"] = std::make_pair( GameMode::TimeOver, NEUTRAL );//std::make_pair(PenaltyWinner_, LEFT);
     M_playmode_map["penalty_winner_r"] = std::make_pair( GameMode::TimeOver, NEUTRAL );//std::make_pair(PenaltyWinner_, RIGHT);
     M_playmode_map["penalty_draw"] = std::make_pair( GameMode::TimeOver, NEUTRAL );//std::make_pair(PenaltyDraw, NEUTRAL);
+
+    M_playmode_map["illegal_defense_r"] = std::make_pair( GameMode::IllegalDefense_, LEFT );
+    M_playmode_map["illegal_defense_l"] = std::make_pair( GameMode::IllegalDefense_, RIGHT );
 }
 
 } // end of no name namespace
@@ -279,6 +282,7 @@ GameMode::isServerCycleStoppedMode() const
     case FreeKickFault_:
     case BackPass_:
     case CatchFault_:
+    case IllegalDefense_:
         return true;
     default:
         return false;
@@ -461,6 +465,10 @@ GameMode::getServerPlayMode() const
         return ( side() == LEFT
                  ? PM_PenaltyScore_Left
                  : PM_PenaltyScore_Right );
+    case IllegalDefense_:
+        return ( side() == LEFT
+                 ? PM_IllegalDefense_Left
+                 : PM_IllegalDefense_Right);
     default:
         return PM_MAX;
     };


### PR DESCRIPTION
This commit will add IllegalDefense Mode to StarterLib you can test this commit by adding this code in sample_player.cpp and in actionImpl function of StarterAgent :
```
if( this->world().gameMode().type() == GameMode::IllegalDefense_){
        std::cout << "------------------IllegalDefense_---------------------" << std::endl;
}
```
use server >16.0 and run with this command for test:

```
rcssserver server::fullstate_l=true server::fullstate_r=true server::stamina_capacity=150000 server::stamina_max=10000server::hear_max=11  server::illegal_defense_duration=1 server::illegal_defense_number=4
```